### PR TITLE
display the game board and make lit

### DIFF
--- a/src/Board.js
+++ b/src/Board.js
@@ -30,18 +30,33 @@ import './Board.css';
  **/
 
 class Board extends Component {
+  static defaultProps = {
+    nrows: 5, 
+    ncols: 5,
+    chanceLightStartsOn: 0.25
+  };
 
   constructor(props) {
     super(props);
-
     // TODO: set initial state
+    this.state = {
+      hasWon: false,
+      board: this.createBoard()
+    }
   }
 
   /** create a board nrows high/ncols wide, each cell randomly lit or unlit */
 
   createBoard() {
     let board = [];
-    // TODO: create array-of-arrays of true/false values
+     // TODO: create array-of-arrays of true/false values
+    for(let y=0; y < this.props.nrows; y++) {
+      let row=[];
+      for(let x=0; x < this.props.ncols; x++) {
+        row.push(Math.random() < this.props.chanceLightStartsOn)
+      }
+      board.push(row);
+    }
     return board
   }
 
@@ -60,14 +75,15 @@ class Board extends Component {
         board[y][x] = !board[y][x];
       }
     }
+  }
 
     // TODO: flip this cell and the cells around it
 
     // win when every cell is turned off
     // TODO: determine is the game has been won
 
-    this.setState({board, hasWon});
-  }
+  //   this.setState({board, hasWon});
+  // }
 
 
   /** Render game board or winning message. */
@@ -81,6 +97,20 @@ class Board extends Component {
     // make table board
 
     // TODO
+    let tblBoard = [];
+    for(let y=0; y < this.props.nrows; y++) {
+      let row = [];
+      for(let x=0; x < this.props.ncols; x++) {
+        let coord=`${y}-${x}`;
+        row.push(<Cell key={coord} isLit={this.state.board[y][x]} />);
+      }
+      tblBoard.push(<tr key={y}>{row}</tr>);
+    }
+    return (
+      <table className="Board">
+        <tbody>{ tblBoard }</tbody>
+      </table>
+    );
   }
 }
 


### PR DESCRIPTION
This gets the game board displaying and random cells to be lit up.  For the game board, three `defaultProps` are added to begin.  This includes setting the number of columns and rows to each have 5.  Then the chance a cell is lit, called `chanceLightStartsOn`, is set as 0.25 (between 0 and 1).  Then the initial state is set, with `hasWon` set to false when starting, and the `board` set to the `createBoard` method.

For the `createBoard` method, this loops over the number of rows and columns, and the second nested loop is filled with boolean values.  This comes from running `Math.random` against the initial chance of 0.25 in the props.  Then each row is pushed onto the board.

In the `return`, a table is added, with a `tblboard` variable to render.  This variable is then created, starting as an empty array.  Then we loop over the rows, and push into this whether the `Cell` component is set to `isLit` as true or false.  Then tablerows are pushed to the `tbleBoard` to be returned.

Also a `key` prop is added.  The table rows (`<tr>`) that are pushed to the `tbleBoard` are given a key of the number `{y}`.  Then each `Cell` is given a key also in this `tblBoard` array as coordinates.  This is done by creating a `coord` variable, equal to a string with the interpolated values of `{y}-{x}`. Now all cells have a unique key of row and column.