### PR TITLE
allows cells to flip when clicked

### DIFF
--- a/src/Board.js
+++ b/src/Board.js
@@ -75,15 +75,18 @@ class Board extends Component {
         board[y][x] = !board[y][x];
       }
     }
-  }
+
+    // Flip initial cell
+    flipCell(y, x);
 
     // TODO: flip this cell and the cells around it
 
     // win when every cell is turned off
-    // TODO: determine is the game has been won
+    // TODO: determine if the game has been won
+    let hasWon = false;
 
-  //   this.setState({board, hasWon});
-  // }
+    this.setState({board, hasWon});
+  }
 
 
   /** Render game board or winning message. */
@@ -102,8 +105,13 @@ class Board extends Component {
       let row = [];
       for(let x=0; x < this.props.ncols; x++) {
         let coord=`${y}-${x}`;
-        row.push(<Cell key={coord} isLit={this.state.board[y][x]} />);
-      }
+        row.push(
+          <Cell 
+            key={coord} 
+            isLit={this.state.board[y][x]} 
+            flipCellsAroundMe = {() => this.flipCellsAround(coord)}
+          />)
+        }
       tblBoard.push(<tr key={y}>{row}</tr>);
     }
     return (


### PR DESCRIPTION
This sets up the functionality for the user to click on a single cell and have it flip between lit and unlit.
In `Board.js`, the prop named `flipCellsAroundMe` is added to the render method.  It is set equal to `this.flipCellsAround` with an argument of `coord`.  Then it is set as an arrow function, so it is not called immediately.

Also in `Board.js`, functionality is set to flip the initial cell with `flipCell(y, x)`, since the function `flipCellsAround` is splitting the string of the `coord` into 2 numbers.  Then we set the state with the new board by using `this.setState({board, hasWon})`.  Also a variable named `hasWon` is created and set to always be false.