### PR TITLE
flips the surrounding cells to the clicked cell

### DIFF
--- a/src/Board.js
+++ b/src/Board.js
@@ -76,10 +76,13 @@ class Board extends Component {
       }
     }
 
-    // Flip initial cell
-    flipCell(y, x);
-
-    // TODO: flip this cell and the cells around it
+    // flip this cell and the cells around it
+    flipCell(y, x);      // Flip initial cell
+    flipCell(y, x - 1);  // Flip left cell
+    flipCell(y, x + 1);  // Flip right cell
+    flipCell(y - 1, x);  // Flip lower cell
+    flipCell(y + 1, x);  // Flip upper cell
+    
 
     // win when every cell is turned off
     // TODO: determine if the game has been won


### PR DESCRIPTION
This sets the functionality of the surrounding cells to flip around a specific cell, when it is clicked.  Now that initial cell is already flipping upon click with `flipCell`, and with the `(y, x)` coordinates passed in, the surrounding cells need flipped. This is done by increments or decrements. 
To flip the cell to the left, `flipCell(y, x - 1)` is added.  
To flip the cell to the right, `flipCell(y, x + 1)` is added.
To flip the lower cell, `flipCell(y - 1, x)` is added.
To flip the upper cell, `flipCell(y + 1, x)` is added.
This will then update the state upon each click of a cell.
