### PR TITLE
style the game title

### DIFF
--- a/src/Board.css
+++ b/src/Board.css
@@ -1,3 +1,90 @@
 .Board {
   margin: 0 auto;
 }
+
+@font-face {
+  font-family: neon;
+  src: url(https://s3-us-west-2.amazonaws.com/s.cdpn.io/707108/neon.ttf);
+}
+
+.container {
+  display: table-cell;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.Board-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+} 
+
+.neon-orange {
+  font-family: neon;
+  color: #FB4264;
+  font-size: 2.5em;
+  text-shadow: 0 0 3vw #F40A35;
+  animation: neon-orange 4s ease infinite;
+  -moz-animation: neon-orange 4s ease infinite;
+  -webkit-animation: neon-orange 4s ease infinite;
+}
+
+@media only screen and (min-width: 500px) {
+  .neon-orange {
+    font-size: 4.4em;
+  }
+}
+
+@media only screen and (min-width: 800px) {
+  .neon-orange {
+    font-size: 5em;
+  }
+}
+
+.neon-blue {
+  font-family: neon;
+  color: #426dfb;
+  font-size: 2.5em;
+  text-shadow: 0 0 3vw #2356FF;
+  animation: neon-blue 2s linear infinite;
+  -moz-animation: neon-blue 2s linear infinite;
+  -webkit-animation: neon-blue 2s linear infinite;
+  -o-animation: neon-blue 2s linear infinite;
+}
+
+@media only screen and (min-width: 500px) {
+  .neon-blue {
+    font-size: 4.4em;
+  }
+}
+
+@media only screen and (min-width: 800px) {
+  .neon-blue {
+    font-size: 5em;
+  }
+}
+
+@keyframes neon-orange {
+  0%,
+  100% {
+    text-shadow: 0 0 1vw #FA1C16, 0 0 3vw #FA1C16, 0 0 10vw #FA1C16, 0 0 10vw #FA1C16, 0 0 .4vw #FED128, .5vw .5vw .1vw #806914;
+    color: #FED128;
+  }
+  50% {
+    text-shadow: 0 0 .5vw #800E0B, 0 0 1.5vw #800E0B, 0 0 5vw #800E0B, 0 0 5vw #800E0B, 0 0 .2vw #800E0B, .5vw .5vw .1vw #40340A;
+    color: #806914;
+  }
+}
+
+@keyframes neon-blue {
+  0%,
+  100% {
+    text-shadow: 0 0 1vw #1041FF, 0 0 3vw #1041FF, 0 0 10vw #1041FF, 0 0 10vw #1041FF, 0 0 .4vw #8BFDFE, .5vw .5vw .1vw #147280;
+    color: #28D7FE;
+  }
+  50% {
+    text-shadow: 0 0 .5vw #082180, 0 0 1.5vw #082180, 0 0 5vw #082180, 0 0 5vw #082180, 0 0 .2vw #082180, .5vw .5vw .1vw #0A3940;
+    color: #146C80;
+  }
+}

--- a/src/Board.js
+++ b/src/Board.js
@@ -89,9 +89,15 @@ class Board extends Component {
       tblBoard.push(<tr key={y}>{row}</tr>);
     }
     return (
-      <table className="Board">
-        <tbody>{ tblBoard }</tbody>
-      </table>
+      <div>
+        <div className="Board-title">
+          <div className="neon-orange">Lights</div>
+          <div className="neon-blue">Out</div>
+        </div>
+        <table className="Board">
+          <tbody>{ tblBoard }</tbody>
+        </table>
+      </div>
     );
   }
 }


### PR DESCRIPTION
This adds a title name, as well as styles, to the overall game.  In `Board.js`, a `div` is added with two `div` elements inside, to display the words "Lights" and "Out".  

In `Board.css`, styles are then provided for the title words.  A `font-family` is added to all fonts.  Also, the board title itself is set as a `flex` item, so that it can be centered.  The word "Lights" is styled with the `neon-orange` class, and the word "Out" is styled with the `neon-blue` class.  The font sizes are set initially, as well as adjusted with a couple breakpoints. In addition, an `animation` is added along with corresponding `keyframes` for both words, to add a pulsating neon effect.