### PR TITLE
add styles for game board and cells

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,32 +1,7 @@
 .App {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
 }
 
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
-  height: 40vmin;
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/src/Board.css
+++ b/src/Board.css
@@ -1,5 +1,29 @@
 .Board {
-  margin: 0 auto;
+  border-radius: 10px;
+  box-shadow: 0 0 25px #fff, -10px 0 40px #f0f, 10px 0 40px #0ff;
+  margin: 0 15px;
+}
+
+@media only screen and (min-width: 600px) {
+  .Board {
+    margin: 0 auto;
+  }
+}
+
+.Board tr:first-child td:first-child {
+  border-radius: 8px 0 0 0;
+}
+
+.Board tr:first-child td:last-child {
+  border-radius: 0 8px 0 0;
+}
+
+.Board tr:last-child td:first-child {
+  border-radius: 0 0 0 8px;
+}
+
+.Board tr:last-child td:last-child {
+  border-radius: 0 0 8px 0; 
 }
 
 @font-face {
@@ -17,7 +41,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
 } 
 
 .neon-orange {

--- a/src/Cell.css
+++ b/src/Cell.css
@@ -1,9 +1,11 @@
 .Cell {
   height: 100px;
   width: 100px;
-  background-color: darkgray;
+  background-color: #263238;
+  border-radius: 1px;
+  transition: background-color 0.7s ease;
 }
 
 .Cell-lit {
-  background-color: white;
+  background-color: #00bcd4;
 }

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -36,4 +36,4 @@ class Cell extends Component {
 }
 
 
-export default Cell
+export default Cell;

--- a/src/index.css
+++ b/src/index.css
@@ -4,14 +4,14 @@ code {
 }
 
 body {
-    margin: 0;
+  margin: 0;
   padding: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #003;
+  background-color: #212121;
   padding-top: 50px;
   color: white;
   text-align: center;


### PR DESCRIPTION
This adds styles for the game board itself, as well as the individual cells on the board. 
In `Cell.css`, I changed the cell background color when turned off, as well as changed the background color when lit.  Also, a `transition` effect was added to delay and fade the cells when turned off and on.  The corners are also rounded a bit.
In the `Board.css`, a `box-shadow` is added to the game board.  Also, a `border-radius` is given to the board, to round the corners.  To compensate for the 4 corners, each of the 4 corner cells are then given a `border-radius` as well, targeting just the corner that needs rounded.
In `index.css`, a `background-color` is added to the entire page.
In `App.css`, a display of `flexbox` is used to center everything.

